### PR TITLE
Fix "uninitialized constant ActiveRecord"

### DIFF
--- a/lib/puma/plugin/heroku.rb
+++ b/lib/puma/plugin/heroku.rb
@@ -14,7 +14,7 @@ Puma::Plugin.create do
       c.workers Integer(ENV['WEB_CONCURRENCY'] || 2)
 
       c.on_worker_boot do
-        if defined? ::ActiveRecord && ::ActiveRecord::Base
+        if defined? ::ActiveRecord::Base
           # Worker specific setup for Rails 4.1+
           # See: https://devcenter.heroku.com/articles/deploying-rails-applications-with-the-puma-web-server#on-worker-boot
           ActiveRecord::Base.establish_connection


### PR DESCRIPTION
The current check for ActiveRecord will always be true, thus resulting in an error when it's not there:

```
ruby -v -e'ActiveRecord::Base if defined? ::ActiveRecord && ::ActiveRecord::Base'
ruby 2.4.5p335 (2018-10-18 revision 65137) [x86_64-linux]
-e:1:in `<main>': uninitialized constant ActiveRecord (NameError)
```

because:

```
ruby -v -e'puts defined? ::ActiveRecord && ::ActiveRecord::Base'
ruby 2.4.5p335 (2018-10-18 revision 65137) [x86_64-linux]
expression
```